### PR TITLE
Fix scut import path and bump version

### DIFF
--- a/_sass/kagami/_scut.scss
+++ b/_sass/kagami/_scut.scss
@@ -1,1 +1,1 @@
-@import "../scut/dist/scut";
+@import "scut/dist/scut";

--- a/jekyll-theme-kagami.gemspec
+++ b/jekyll-theme-kagami.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |spec|
   spec.name          = "jekyll-theme-kagami"
-  spec.version       = "0.2.2"
+  spec.version       = "0.2.3"
 
   spec.authors       = ["kamikat"]
   spec.email         = ["kamikat@banana.moe"]


### PR DESCRIPTION
## Summary
- fix scut import path
- bump gem version to 0.2.3

## Testing
- `bundle install`
- `bundle exec jekyll build --source example`
- `gem build jekyll-theme-kagami.gemspec`


------
https://chatgpt.com/codex/tasks/task_e_688f1324d2248322bf813fb3d5b2ddef