### PR TITLE
Reduce blog line spacing for improved readability

### DIFF
--- a/_sass/kagami/_typography.scss
+++ b/_sass/kagami/_typography.scss
@@ -1,7 +1,7 @@
-[lang^="en"]      { line-height: 1.6; @include font-serif; }
-[lang^="zh-Hans"] { line-height: 1.8; @include font-serif-zh-Hans; }
-[lang^="zh-Hant"] { line-height: 1.8; @include font-serif-zh-Hant; }
-[lang^="ja"]      { line-height: 1.8; @include font-serif-ja; }
+[lang^="en"]      { line-height: 1.3; @include font-serif; }
+[lang^="zh-Hans"] { line-height: 1.4; @include font-serif-zh-Hans; }
+[lang^="zh-Hant"] { line-height: 1.4; @include font-serif-zh-Hant; }
+[lang^="ja"]      { line-height: 1.4; @include font-serif-ja; }
 
 body {
   color: $content-color;
@@ -98,7 +98,7 @@ article {
     code {
       color: inherit;
       background: none;
-      line-height: 1.6;
+      line-height: 1.3;
     }
   }
 


### PR DESCRIPTION
## Summary
- lower default line-height for blog text to tighten spacing
- match code block line-height with new text spacing

## Testing
- `bundle install`
- `bundle exec jekyll build -s example`


------
https://chatgpt.com/codex/tasks/task_e_688f5325b6e483228eb40994eb15771f