### PR TITLE
Fix code block width and inline code colors

### DIFF
--- a/_sass/kagami.scss
+++ b/_sass/kagami.scss
@@ -10,8 +10,8 @@ $spacing-unit: 32px;
 $content-color: #3c3c3c;
 $background-color: #fff;
 $border-color: #f0f0f0;
-$inline-code-color: #d32f2f;
-$inline-code-background: #fff6f6;
+$inline-code-color: #3c3c3c;
+$inline-code-background: #f2f2fa;
 $block-code-background: #f2f2fa;
 $mark-background: rgba(yellow, 0.35);
 

--- a/_sass/kagami/_layout.scss
+++ b/_sass/kagami/_layout.scss
@@ -56,17 +56,11 @@ article {
   pre {
     position: relative;
     overflow: hidden;
+    padding: (0.5 * $vspacing) $hspacing;
 
     code {
       display: block;
       overflow-x: auto;
-    }
-
-    @include exdent-horizontally($hspacing, "code");
-    @include exdent-vertically(0.5 * $vspacing, "code");
-
-    @media screen and (min-width: $content-width) {
-      @include exdent-horizontally(2 * $hspacing, "code");
     }
   }
 


### PR DESCRIPTION
## Summary
- ensure preformatted blocks align with article width
- switch inline code styling to neutral theme colors

## Testing
- `bundle install`
- `bundle exec jekyll build -s example`

------
https://chatgpt.com/codex/tasks/task_e_688f5a4ce0d08322b87e06a56e2e76ae